### PR TITLE
chore: Use actions/checkout@v2 temporary

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Cleanup
         run: |


### PR DESCRIPTION
dependabot がエラーになる。

actions/checkout のバージョンが混在していることが原因の可能性がるので全体でそろえる。