### PR TITLE
ci: Use node 26 for release workflows

### DIFF
--- a/.github/workflows/gh_pkg.yaml
+++ b/.github/workflows/gh_pkg.yaml
@@ -20,7 +20,7 @@ jobs:
       # .npmrc ファイルをセットアップして GitHub Packages に公開する
       - uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '26.x'
           registry-url: 'https://npm.pkg.github.com'
           # デフォルトはワークフローファイルを所有するユーザまたは Organization
           # scope: '@hankei6km'

--- a/.github/workflows/npm_pkg.yaml
+++ b/.github/workflows/npm_pkg.yaml
@@ -32,7 +32,7 @@ jobs:
       # npm に公開するように .npmrc ファイルを設定する
       - uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '26.x'
           registry-url: 'https://registry.npmjs.org'
 
       # https://docs.github.com/ja/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows


### PR DESCRIPTION
Node のバージョンを上げただけ。
Trusted Publishing 対応には設定変更とワークフローの修正が必要。
